### PR TITLE
Setting severity level so non prod alerts go to non prod alerts channel

### DIFF
--- a/helm_deploy/prisoner-content-hub-feedback-exporter/templates/monitoring.yaml
+++ b/helm_deploy/prisoner-content-hub-feedback-exporter/templates/monitoring.yaml
@@ -16,7 +16,7 @@ spec:
       expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="{{ .Release.Namespace }}"} > 600
       for: 10m
       labels:
-        severity: pfs-hub
+        severity: {{ .Values.severity }}
     - alert: KubeJobCompletion
       annotations:
         message: CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }} failed.
@@ -25,4 +25,4 @@ spec:
         kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="{{ .Release.Namespace }}"} > 0
       for: 10m
       labels:
-        severity: pfs-hub
+        severity: {{ .Values.severity }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,4 @@
 ---
 # Per environment values which override defaults in prisoner-content-hub-feedback-exporter/values.yaml
-
+severity: hub_alerts_non_prod
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,4 @@
 ---
 # Per environment values which override defaults in prisoner-content-hub-feedback-exporter/values.yaml
-
+severity: pfs-hub
 

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -1,4 +1,4 @@
 ---
 # Per environment values which override defaults in prisoner-content-hub-feedback-exporter/values.yaml
-
+severity: hub_alerts_non_prod
 


### PR DESCRIPTION
### Context

https://trello.com/c/AGEz41jA

### Intent

dev alerts should go into the non prod alert channel


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development