### PR TITLE
add extra feedback data fields

### DIFF
--- a/job/__tests__/feedbackJob.spec.ts
+++ b/job/__tests__/feedbackJob.spec.ts
@@ -35,21 +35,21 @@ describe('feedback retriever', () => {
     })
 
     it('should pass the results of the retriever to the sheets uploader', async () => {
-      const feedbackItem = new FeedbackItem({})
+      const feedbackItem = new FeedbackItem('', {})
       feedbackRetriever.retrieve.mockResolvedValue([feedbackItem])
       await feedbackJob.run(new Date('22 Feb 2021 00:00:00 GMT'))
       expect(sheetsUploader.upload).toHaveBeenCalledWith([feedbackItem])
     })
 
     it('should not send results of the retriever to the email sender', async () => {
-      const feedbackItem = new FeedbackItem({})
+      const feedbackItem = new FeedbackItem('', {})
       feedbackRetriever.retrieve.mockResolvedValue([feedbackItem])
       await feedbackJob.run(new Date('22 Feb 2021 00:00:00 GMT'))
       expect(emailSender.send).not.toBeCalled()
     })
 
     it('should pass the results of the retriever to the email sender', async () => {
-      const feedbackItem = new FeedbackItem({})
+      const feedbackItem = new FeedbackItem('', {})
       feedbackRetriever.retrieve.mockResolvedValue([feedbackItem])
       await feedbackJob.run(new Date('21 Feb 2021 00:00:00 GMT'))
       expect(emailSender.send).toHaveBeenCalledWith([feedbackItem])

--- a/job/__tests__/feedbackRetriever.spec.ts
+++ b/job/__tests__/feedbackRetriever.spec.ts
@@ -48,6 +48,7 @@ describe('feedback retriever', () => {
         hits: {
           hits: [
             {
+              _id: '2b1e137e-fe2d-4972-a864-afkjlflgj567',
               _source: {
                 date: '2021-06-03',
                 title: 'Park run',
@@ -57,6 +58,7 @@ describe('feedback retriever', () => {
                 sessionId: 'kj453eeeafjlkj5wf44n',
                 establishment: 'Wayland',
                 series: 'Exercise',
+                categories: 'Workout',
               },
             },
           ],
@@ -65,7 +67,7 @@ describe('feedback retriever', () => {
       const response = await feedbackRetriever.retrieve('2021-06-03', '2021-06-06')
 
       expect(response).toStrictEqual([
-        new FeedbackItem({
+        new FeedbackItem('2b1e137e-fe2d-4972-a864-afkjlflgj567', {
           date: '2021-06-03',
           title: 'Park run',
           contentType: 'Article',
@@ -74,6 +76,7 @@ describe('feedback retriever', () => {
           sessionId: 'kj453eeeafjlkj5wf44n',
           establishment: 'Wayland',
           series: 'Exercise',
+          categories: 'Workout',
         }),
       ])
     })
@@ -83,6 +86,7 @@ describe('feedback retriever', () => {
         hits: {
           hits: [
             {
+              _id: '2b1e137e-fe2d-4972-a864-kh231hhkkh667',
               _source: {
                 Field1: 'fsjhf',
                 date: '2021-06-03',
@@ -94,6 +98,7 @@ describe('feedback retriever', () => {
                 sessionId: 'kj453eeeafjlkj5wf44n',
                 establishment: 'Wayland',
                 series: 'Exercise',
+                categories: 'Workout',
                 Field3: 'fsjhf',
               },
             },
@@ -103,7 +108,7 @@ describe('feedback retriever', () => {
       const response = await feedbackRetriever.retrieve('2021-06-03', '2021-06-06')
 
       expect(response).toStrictEqual([
-        new FeedbackItem({
+        new FeedbackItem('2b1e137e-fe2d-4972-a864-kh231hhkkh667', {
           Field1: 'fsjhf',
           date: '2021-06-03',
           title: 'Park run',
@@ -114,6 +119,7 @@ describe('feedback retriever', () => {
           sessionId: 'kj453eeeafjlkj5wf44n',
           establishment: 'Wayland',
           series: 'Exercise',
+          categories: 'Workout',
           Field3: 'fsjhf',
         }),
       ])
@@ -124,6 +130,7 @@ describe('feedback retriever', () => {
         hits: {
           hits: [
             {
+              _id: '2b1e137e-fe2d-4972-a864-18dgdgh456',
               _source: {
                 title: 'Park run',
                 contentType: 'Article',
@@ -138,7 +145,7 @@ describe('feedback retriever', () => {
       const response = await feedbackRetriever.retrieve('2021-06-03', '2021-06-06')
 
       expect(response).toStrictEqual([
-        new FeedbackItem({
+        new FeedbackItem('2b1e137e-fe2d-4972-a864-18dgdgh456', {
           title: 'Park run',
           contentType: 'Article',
           comment: 'Love it',

--- a/job/__tests__/sheetsUploader.spec.ts
+++ b/job/__tests__/sheetsUploader.spec.ts
@@ -1,7 +1,7 @@
 import { FeedbackItem } from '../types'
 import SheetsUploader from '../sheetsUploader'
 
-const FEEDBACK_ITEM = new FeedbackItem({
+const FEEDBACK_ITEM = new FeedbackItem('djhshf-dhfjhadfh-ojgjgt', {
   Field1: 'fsjhf',
   date: '2021-06-03',
   title: 'Park run',
@@ -12,6 +12,7 @@ const FEEDBACK_ITEM = new FeedbackItem({
   sessionId: 'kj453eeeafjlkj5wf44n',
   establishment: 'Wayland',
   series: 'Exercise',
+  categories: 'Workout',
   Field3: 'fsjhf',
 })
 

--- a/job/emailSender.ts
+++ b/job/emailSender.ts
@@ -28,7 +28,8 @@ export default class EmailSender {
   }
 
   private async uploadFileContent(items: FeedbackItem[]) {
-    const csv = items.map(f => f.formattedRow()).join('\n')
+    const feedbackHeader = FeedbackItem.getFeedbackHeader().join(', ')
+    const csv = `${feedbackHeader}\n${items.map(f => f.formattedRow()).join('\n')}`
 
     const contents = items.length ? csv : 'No feedback for this establishment and timeframe\n'
     return this.notifyApi.prepareUpload(Buffer.from(contents), true)

--- a/job/feedbackRetriever.ts
+++ b/job/feedbackRetriever.ts
@@ -3,7 +3,7 @@ import config from './config'
 import { FeedbackItem } from './types'
 import type HttpClient from './utils/httpClient'
 
-type Hit = { _source: Record<string, string> }
+type Hit = { _id: string; _source: Record<string, string> }
 
 class FeedbackRetriever {
   constructor(private readonly httpClient: HttpClient) {}
@@ -18,7 +18,7 @@ class FeedbackRetriever {
     const response = await this.httpClient.post(config.elasticsearch.feedback, esbRequest)
     const results: Hit[] = response?.hits?.hits || []
 
-    return results.map(({ _source: source }) => new FeedbackItem(source))
+    return results.map(({ _id: id, _source: source }) => new FeedbackItem(id, source))
   }
 }
 

--- a/job/types.ts
+++ b/job/types.ts
@@ -1,5 +1,4 @@
 /* eslint-disable lines-between-class-members */
-
 export class FeedbackItem {
   public readonly date: string
   public readonly title: string
@@ -9,9 +8,26 @@ export class FeedbackItem {
   public readonly sessionId: string
   public readonly establishment: string
   public readonly series: string
+  public readonly feedbackId: string
+  public readonly categories: string
   public readonly row: string[]
 
-  constructor(row: Record<string, string>) {
+  public static getFeedbackHeader() {
+    return [
+      'Date',
+      'Title',
+      'Content Type',
+      'Sentiment',
+      'Comment',
+      'Session Id',
+      'Establishment',
+      'Series',
+      'Categories',
+      'Feedback Id',
+    ]
+  }
+
+  constructor(feedbackId: string, row: Record<string, string>) {
     this.date = row.date
     this.title = row.title
     this.contentType = row.contentType
@@ -20,6 +36,8 @@ export class FeedbackItem {
     this.sessionId = row.sessionId
     this.establishment = row.establishment
     this.series = row.series
+    this.categories = row.categories
+    this.feedbackId = feedbackId
     this.row = [
       this.date,
       this.title,
@@ -29,6 +47,8 @@ export class FeedbackItem {
       this.sessionId,
       this.establishment,
       this.series,
+      this.categories,
+      this.feedbackId,
     ]
   }
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/t6seqgPm
https://trello.com/c/Nwsw0rJ4

### Intent

> What changes are introduced by this PR that correspond to the above card?

Currently, the feedback report only shows what series a page is associated with (if that page has a series). We want to add the category to give more information.

We are also recording sessionId in the feedback summary, but this serves no purpose. FeedbackId would allow us to link prisonerIds to feedback comments.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development