### PR TITLE
LNP-272: move from elasticsearch to opensearch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 ### Context
 
-> Does this issue have a Trello card?
+> Does this issue have a Jira ticket?
 
 > If this is an issue, do we have steps to reproduce?
 
 ### Intent
 
-> What changes are introduced by this PR that correspond to the above card?
+> What changes are introduced by this PR that correspond to the above ticket?
 
 > Would this PR benefit from screenshots?
 
@@ -18,7 +18,7 @@
 
 ### Checklist
 
-- [ ] This PR contains **only** changes related to the above card
+- [ ] This PR contains **only** changes related to the above ticket
 - [ ] Tests have been added/updated to cover the change
 - [ ] Documentation has been updated where appropriate
 - [ ] Tested in Development

--- a/helm_deploy/prisoner-content-hub-feedback-exporter/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-feedback-exporter/templates/_envs.tpl
@@ -19,8 +19,8 @@ env:
     - name: ELASTICSEARCH_ENDPOINT
       valueFrom:
         secretKeyRef:
-            name: {{ include "app.name" . }}
-            key: ELASTICSEARCH_ENDPOINT
+            name: pfs-opensearch-proxy-url
+            key: proxy_url
 
     - name: GOV_NOTIFY_API_KEY
       valueFrom:


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-272

> If this is an issue, do we have steps to reproduce?

Wait overnight.
Observe that no new feedback is visible in the feedback report.

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

This PR changes the application to use the exported terraform secret for the new opensearch resource rather than the address hardcoded in the application secret that points at the old (and non-existent) elasticsearch

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No. We could consider deleting the ELASTICSEARCH_ENDPOINT from the app secret after deployment as tidy up but this is not necessary to implement the fix.

### Checklist

- [ ] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
